### PR TITLE
tests: add unit test to get_user on database ctx

### DIFF
--- a/meowpi/database/mongo.py
+++ b/meowpi/database/mongo.py
@@ -33,7 +33,7 @@ class MongoDatabase:
         is_already_created = self.coll.count_documents({'username': user_data.username})
         if is_already_created:
             raise UserAlreadyCreated(f"User with username {user_data.username} is already created.")
-        created_user_id = self.coll.insert_one(user_data).inserted_id
+        created_user_id = self.coll.insert_one(user_data.dict()).inserted_id
         created_user_id = str(created_user_id)
         return created_user_id
         

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode = auto

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@ uvicorn
 pymongo
 python-multipart
 python-jose
+pymongo-inmemory
+pytest-asyncio
+pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[pymongo_inmemory]
+operating_system = ubuntu
+os_version = 18
+mongod_port = 27019

--- a/tests/database/test_database.py
+++ b/tests/database/test_database.py
@@ -1,0 +1,28 @@
+import pydantic
+import pytest
+from meowpi.database.mongo import *
+from pymongo_inmemory import MongoClient
+
+
+@pytest.fixture
+def user_data():
+    payload = {
+        'full_name': 'Abluble de Almeida',
+        'birth_date': 10/10/1992,
+        'email': 'abluble@gmail.com',
+        'username': 'AbluCat',
+        'password': 'Ablu123',
+        'hashed_password': 'ablu123ablu123',
+        'cats': [],
+    }
+    instancepayload = CreateUserSchema(**payload)
+    return instancepayload
+
+@pytest.mark.asyncio
+async def test_get_user_valid(user_data):
+    client_test = MongoClient()
+    db_test = MongoDatabase(client_test)
+    new_test_user = await db_test.create_user(user_data)
+    test_get_user = await db_test.get_user('AbluCat')
+    assert test_get_user
+    print(test_get_user)

--- a/tests/database/test_database.py
+++ b/tests/database/test_database.py
@@ -24,5 +24,4 @@ async def test_get_user_valid(user_data):
     db_test = MongoDatabase(client_test)
     new_test_user = await db_test.create_user(user_data)
     test_get_user = await db_test.get_user('AbluCat')
-    assert test_get_user
-    print(test_get_user)
+    assert test_get_user, test_get_user

--- a/tests/database/test_database.py
+++ b/tests/database/test_database.py
@@ -1,6 +1,6 @@
 import pydantic
 import pytest
-from meowpi.database.mongo import *
+from meowpi.database.mongo import MongoDatabase
 from pymongo_inmemory import MongoClient
 
 


### PR DESCRIPTION
Add mongo inmemory for tests, add pytest.ini for warnings treatment,
fix create_user on database context, transforming "user_data" into a
dict. Add the following resources on requirements.txt: pymongo-inmemory,
pytest and pytest-asyncio. Created setup for database inmemory configs.
Created get_user unit test and tests' repositories.